### PR TITLE
Preserve existing whitespace and newlines in answers

### DIFF
--- a/client/src/styles/QuestionBoard.css
+++ b/client/src/styles/QuestionBoard.css
@@ -49,6 +49,7 @@ body{
   font-size: 18px;
   line-height: 1.5em;
   margin-bottom: 10px;
+  white-space: pre-wrap;
 }
 
 .answer-image {


### PR DESCRIPTION
Small improvement PR to render answers.

E.g
<img width="901" alt="whitespace improvement" src="https://user-images.githubusercontent.com/1127458/76712994-c909fc80-66da-11ea-9249-a425251ba2c8.png">
