### PR TITLE
add proxy url that resolve cors

### DIFF
--- a/client/src/components/QuestionBoard.js
+++ b/client/src/components/QuestionBoard.js
@@ -69,7 +69,7 @@ export default class QuestionBoard extends Component {
                       <List.Item key={index}>
                         <List.Icon name='linkify' />
                         <List.Content>
-                        { link && <ReactTinyLink cardSize="small" showGraphic={true} maxLine={2} minLine={1} url={link} /> }
+                        { link && <ReactTinyLink cardSize="small" showGraphic={true} maxLine={2} minLine={1} url={link} proxyUrl={config.corsProxyUrl} /> }
                         </List.Content>
                       </List.Item>
                     )}
@@ -77,7 +77,7 @@ export default class QuestionBoard extends Component {
                       <List.Item key={index}>
                         <List.Icon name='linkify' />
                         <List.Content>
-                          { source && <ReactTinyLink cardSize="small" showGraphic={true} maxLine={2} minLine={1} url={source} /> }
+                          { source && <ReactTinyLink cardSize="small" showGraphic={true} maxLine={2} minLine={1} url={source} proxyUrl={config.corsProxyUrl} /> }
                         </List.Content>
                       </List.Item>
                     )}

--- a/client/src/config/base.json
+++ b/client/src/config/base.json
@@ -1,3 +1,4 @@
 {
-  "domainURL": "http://localhost:8000"
+  "domainURL": "http://localhost:8000",
+  "corsProxyUrl": "https://cors-anywhere.herokuapp.com"
 }

--- a/client/src/config/prod.json
+++ b/client/src/config/prod.json
@@ -1,3 +1,4 @@
 {
-  "domainURL": "https://notzwu-node-rg.azurewebsites.net"
+  "domainURL": "https://notzwu-node-rg.azurewebsites.net",
+  "corsProxyUrl": "https://covid19webapp-cors-anywhere.herokuapp.com"
 }


### PR DESCRIPTION
`ReactTinyLink` package that is used to render rich previews of link uses `https://cors-anywhere.herokuapp.com/` to resolve cors but due to huge number of request sent from origin `https://www.covid19webapp.com` (limit is 200 request per 60 minutes), sometime, it couldn't render the meta information as expected.

![Screenshot from 2020-03-20 22-44-19](https://user-images.githubusercontent.com/9588306/77188081-8b074100-6afd-11ea-99e7-9b600826f0c5.png)

Therefore, hosted `CORS Anywhere` on heroku to resolve this issue.
