### PR TITLE
Use a preview for long messages

### DIFF
--- a/client/src/components/AnswerItem.js
+++ b/client/src/components/AnswerItem.js
@@ -1,14 +1,36 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { List } from 'semantic-ui-react'
 
-const AnswerItem = (props) => (
-  <List.Item>
-    <List.Icon name='marker' />
-    <List.Content>
-      <List.Description>
-        <span className='qAnswer'>{props.answer}</span>
-      </List.Description>
-    </List.Content>
-  </List.Item>
-)
+const PREVIEW_CHARS = 200
+
+const AnswerItem = (props) => {
+  const [expanded, setExpanded] = useState(false);
+  
+  return (
+    <List.Item>
+      <List.Icon name='marker' />
+      <List.Content>
+        <List.Description>
+          { expanded 
+          ? 
+            <>
+              <span className='qAnswer'>{props.answer}</span>
+              <br/>
+              <a onClick={() => setExpanded(false)}>Show less</a>
+            </>
+          : 
+            <>
+              <span className='qAnswer'>
+                {props.answer.substring(0, PREVIEW_CHARS)}
+                {props.answer.length > PREVIEW_CHARS ? '...' : ''}
+              </span>
+              <br/>
+              <a onClick={() => setExpanded(true)}>Show more</a>
+            </>
+          }
+        </List.Description>
+      </List.Content>
+    </List.Item>
+  )
+}
 export default AnswerItem


### PR DESCRIPTION
Not sure what the best way to reference issues from Trello is, but the issue is titled "Long answers, show snippet only, first few lines, expand button (helps with long answers)". 

Very simple implementation, essentially cuts off answers by a constant char count, and allows user to expand the answer by clicking the "show more" button. 