### PR TITLE
don't display show more if the text is not long enough

### DIFF
--- a/client/src/components/AnswerItem.js
+++ b/client/src/components/AnswerItem.js
@@ -12,20 +12,21 @@ const AnswerItem = (props) => {
       <List.Icon name="marker" />
       <List.Content>
         <List.Description>
-          {expanded ? (
+          {props.answer.length > PREVIEW_CHARS ? (
             <>
-              <span className="qAnswer">{props.answer}</span>
+              <span className="qAnswer">
+                {expanded
+                  ? props.answer
+                  : `${props.answer.substring(0, PREVIEW_CHARS)}...`}
+              </span>
               <br />
-              <a onClick={() => setExpanded(false)}>Show less</a>
+              <a onClick={() => setExpanded(!expanded)}>
+                Show {expanded ? 'less' : 'more'}
+              </a>
             </>
           ) : (
             <>
-              <span className="qAnswer">
-                {props.answer.substring(0, PREVIEW_CHARS)}
-                {props.answer.length > PREVIEW_CHARS ? '...' : ''}
-              </span>
-              <br />
-              <a onClick={() => setExpanded(true)}>Show more</a>
+              <span className="qAnswer">{props.answer}</span>
             </>
           )}
         </List.Description>


### PR DESCRIPTION
## Motivation

Right now we have a `show more` and `show less` text on answers. But these text are displayed even if the answers are short and don't need to be expanded. 

## Implementation

Only `Show more` if the text is longer than 200 chars

## Screenshots/Links

![show-more](https://user-images.githubusercontent.com/9588306/77547275-181f1100-6ed5-11ea-8d01-21fcd22522ac.gif)
