### PR TITLE
Feature/add log in log out button

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -29,7 +29,7 @@ export class App extends Component {
               />
               <Route exact path="/physician-public" component={PhysicianView} />
               <Route exact path="/about" component={About} />
-              <Route exact path="/" component={PatientBoard} />
+              <Route exact path="/" component={AuthProvider(PatientBoard)} />
             </Router>
           </Provider>
         </I18nextProvider>

--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -92,6 +92,25 @@ class NavMenu extends Component {
                       DISCLAIMER
                     </a>
                   </li>
+                  {this.props.account ? (
+                    <Button
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={this.props.onSignOut}
+                      id="logInlogOut"
+                    >
+                      Log out
+                    </Button>
+                  ) : (
+                    <Button
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href="/bIiOOIIqgwEXwUU3SaD0F9"
+                      id="logInlogOut"
+                    >
+                      Log in
+                    </Button>
+                  )}
                 </ul>
                 <div>
                   <div>

--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -34,10 +34,7 @@ class NavMenu extends Component {
       <div>
         <Button id="menu" className="ui icon button" onClick={this.showMenu}>
           {' '}
-          <i
-            className={`bars icon ${this.props.lightMenu ? 'light' : ''}`}
-            onClick={this.showMenu}
-          />
+          <i className="bars icon" onClick={this.showMenu} />
         </Button>
 
         {this.state.showMenu ? (

--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -91,19 +91,16 @@ class NavMenu extends Component {
                   </li>
                   {this.props.account ? (
                     <Button
-                      target="_blank"
-                      rel="noopener noreferrer"
                       onClick={this.props.onSignOut}
-                      id="logInlogOut"
+                      className="logInlogOut"
                     >
                       Log out
                     </Button>
                   ) : (
                     <Button
                       target="_blank"
-                      rel="noopener noreferrer"
                       href="/bIiOOIIqgwEXwUU3SaD0F9"
-                      id="logInlogOut"
+                      className="logInlogOut"
                     >
                       Log in
                     </Button>

--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Button } from 'semantic-ui-react';
-
+import { withRouter } from 'react-router-dom';
 import styles from '../styles/NavLink.css';
 
 class NavMenu extends Component {
@@ -89,22 +89,26 @@ class NavMenu extends Component {
                       DISCLAIMER
                     </a>
                   </li>
-                  {this.props.account ? (
-                    <Button
-                      onClick={this.props.onSignOut}
-                      className="logInlogOut"
-                    >
-                      Log out
-                    </Button>
-                  ) : (
-                    <Button
-                      target="_blank"
-                      href="/bIiOOIIqgwEXwUU3SaD0F9"
-                      className="logInlogOut"
-                    >
-                      Log in
-                    </Button>
-                  )}
+                  <div>
+                    {this.props.account ? (
+                      <Button
+                        onClick={this.props.onSignOut}
+                        className="logInlogOut"
+                      >
+                        Log out
+                      </Button>
+                    ) : (
+                      <Button
+                        target="_blank"
+                        onClick={() =>
+                          this.props.history.push('/bIiOOIIqgwEXwUU3SaD0F9')
+                        }
+                        className="logInlogOut"
+                      >
+                        Log in
+                      </Button>
+                    )}
+                  </div>
                 </ul>
                 <div>
                   <div>
@@ -139,4 +143,4 @@ class NavMenu extends Component {
   }
 }
 
-export default NavMenu;
+export default withRouter(NavMenu);

--- a/client/src/components/PhysicianView.js
+++ b/client/src/components/PhysicianView.js
@@ -11,7 +11,7 @@ import {
   fetchQuestions,
 } from '../actions';
 
-import PhysicianLogin from '../components/PhysicianLogin';
+import PhysicianLogin from './PhysicianLogin';
 import AnswerForm from './AnswerForm';
 import NavMenu from './NavLink';
 
@@ -35,7 +35,10 @@ class PhysicianView extends Component {
       <PhysicianLogin onSignIn={this.props.onSignIn} />
     ) : (
       <>
-        <NavMenu />
+        <NavMenu
+          account={this.props.account}
+          onSignOut={this.props.onSignOut}
+        />
         <div>
           <Menu secondary>
             <Menu.Menu position="right">
@@ -112,14 +115,14 @@ class PhysicianView extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     unansweredQuestions: state.questionBoard.unansweredQuestions,
     questions: state.questionBoard.questions,
   };
 };
 
-const mapDispatchToProps = dispatch =>
+const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
       fetchUnansweredQuestions,

--- a/client/src/components/StickyHeader.js
+++ b/client/src/components/StickyHeader.js
@@ -19,6 +19,8 @@ class StickyHeader extends Component {
       addSuccess,
       messageActive,
       newQ,
+      account,
+      onSignOut,
     } = this.props;
 
     return (
@@ -33,7 +35,7 @@ class StickyHeader extends Component {
             handleSearchChange={handleSearchChange}
             handleKeyPress={handleKeyPress}
           />
-          <Menu lightMenu />
+          <Menu account={account} onSignOut={onSignOut} />
           {addSuccess && messageActive && (
             <Message positive>
               <Message.Header>We've submitted your question</Message.Header>

--- a/client/src/containers/PatientBoard.js
+++ b/client/src/containers/PatientBoard.js
@@ -123,6 +123,8 @@ class PatientBoard extends Component {
           messageActive={this.props.messageActive}
           newQ={this.props.newQ}
           handleKeyPress={this.handleKeyPress}
+          account={this.props.account}
+          onSignOut={this.props.onSignOut}
         />
         <div className="containerDiv">
           {this.state.displayNewQuestion && (

--- a/client/src/styles/NavLink.css
+++ b/client/src/styles/NavLink.css
@@ -83,3 +83,13 @@ a.ui.button {
   margin-left: 0.25em;
   margin-bottom: 15px;
 }
+
+#logInlogOut {
+  color: white;
+  font-size: 20px;
+  font-weight: 400;
+  white-space: nowrap;
+  letter-spacing: 0.3px;
+  background: transparent;
+  height: 50px;
+}

--- a/client/src/styles/NavLink.css
+++ b/client/src/styles/NavLink.css
@@ -84,7 +84,7 @@ a.ui.button {
   margin-bottom: 15px;
 }
 
-a.ui.button.logInlogOut {
+button.ui.button.logInlogOut {
   color: white;
   font-size: 20px;
   font-weight: 400;

--- a/client/src/styles/NavLink.css
+++ b/client/src/styles/NavLink.css
@@ -84,7 +84,7 @@ a.ui.button {
   margin-bottom: 15px;
 }
 
-#logInlogOut {
+a.ui.button.logInlogOut {
   color: white;
   font-size: 20px;
   font-weight: 400;


### PR DESCRIPTION
## Motivation
Adds a Log in and Log out button to the navigation menu.

[Trello card](https://trello.com/c/M97mQWbf/51-3b-add-the-profile-icon)

## Implementation
The figma design has a user icon next to the navigation menu item, however I've opted to add the buttons to the nav menu to cater for smaller screens. Happy to hear feedback on this.

The Log In button redirects the user to the Physician Log in page, as opposed to showing the Log In pop up. Showing the pop up is a trivial change though it means the user does not get an alert that they have successfully logged in.

The Log Out button simply logs the user out.

I've also removed a redundant class,`light`

## Screenshots/Links

Main View - Log In button:
![image](https://user-images.githubusercontent.com/13524187/77834570-95e55580-713d-11ea-9c2a-615bcb55bbbc.png)

Main View - Log Out button:
![image](https://user-images.githubusercontent.com/13524187/77834661-2a4fb800-713e-11ea-8dc5-39070569d3d2.png)

Physician View - Log Out button: 
![image](https://user-images.githubusercontent.com/13524187/77834632-04c2ae80-713e-11ea-8a21-816efa157ad2.png)
