### PR TITLE
Close the ask a question modal after user submits question. Fixes #94

### DIFF
--- a/client/public/locales/de/patientBoard.json
+++ b/client/public/locales/de/patientBoard.json
@@ -1,7 +1,7 @@
 {
   "addQuestion": {
     "askAQuestion": "[DE] Ask a question",
-    "description": "[DE] Description"
+    "question": "[DE] Question"
   },
   "stickyHeader": {
     "questionSubmitted": "[DE] We've submitted your question",

--- a/client/public/locales/en/patientBoard.json
+++ b/client/public/locales/en/patientBoard.json
@@ -1,7 +1,7 @@
 {
   "addQuestion": {
     "askAQuestion": "Ask a question",
-    "description": "Description"
+    "question": "Question"
   },
   "stickyHeader": {
     "questionSubmitted": "We've submitted your question",

--- a/client/src/containers/AddQuestionForm.js
+++ b/client/src/containers/AddQuestionForm.js
@@ -14,10 +14,10 @@ class AddQuestionForm extends Component {
     };
   }
 
-  handleSubmit = () => {
+  handleSubmit = async () => {
     const { dispatch } = this.props;
-    dispatch(postQuestion(this.state.value));
-    this.setState({ value: '' });
+    await dispatch(postQuestion(this.state.value));
+    this.setState({ value: '', showModal: false });
   };
 
   handleChange = (e, { value }) => this.setState({ value });

--- a/client/src/containers/AddQuestionForm.js
+++ b/client/src/containers/AddQuestionForm.js
@@ -59,9 +59,8 @@ class AddQuestionForm extends Component {
         <Modal.Content>
           <Modal.Description>
             <Form onSubmit={this.handleSubmit}>
-              <Form.Input fluid label="Title" />
               <Form.TextArea
-                label={t('patientBoard:addQuestion.description')}
+                label={t('patientBoard:addQuestion.question')}
                 value={this.state.value}
                 onChange={this.handleChange}
               />


### PR DESCRIPTION
## Motivation

There was an issue where when user asked a question, they wouldn't get visual feedback on what happened and nor would the modal close. This PR fixed that.

Additional fix:

- Remove the title field from the `Ask a Question` form
- Make the label of the description field `Question`