### PR TITLE
"Show More" button flow

### DIFF
--- a/client/src/components/AnswerForm.js
+++ b/client/src/components/AnswerForm.js
@@ -173,7 +173,7 @@ class AnswerForm extends Component {
             <List>
               {this.state[`newAnswers${q.id}`] &&
                 this.state[`newAnswers${q.id}`].map((answer, index) => {
-                  return <AnswerItem answer={answer} key={index} />;
+                  return <AnswerItem answer={answer} key={index}/>;
                 })}
             </List>
           </Message>

--- a/client/src/components/AnswerItem.js
+++ b/client/src/components/AnswerItem.js
@@ -2,12 +2,69 @@
 import React, { useState } from 'react';
 import { List } from 'semantic-ui-react';
 
+import '../styles/AnswerItem.css'
+
 import avatar from '../assets/images/askco-avatar.svg';
 
 const PREVIEW_CHARS = 200;
 
+
+
+
 const AnswerItem = (props) => {
   const [expanded, setExpanded] = useState(false);
+  const [overflow, setOverflow] = useState(checkOverflow(props.drewval));
+  // const [overflow, setOverflow] = useState(true);
+
+  
+  var myBool = checkOverflow(props.drewval);
+
+  function componentDidMount() {
+    setOverflow(checkOverflow(props.drewval));
+    console.log("I RUN");
+  }
+
+  function output(x) {
+    console.log("hello!!!!!!!!");
+    
+    console.log(x);
+    var el = document.getElementById(x);
+
+    var isOverflowing = el.clientWidth < el.scrollWidth 
+    || el.clientHeight < el.scrollHeight;
+
+    console.log("Overflowing? " + checkOverflow(x));
+
+    console.log("State of overflow: " + overflow);
+    console.log("State of exapnsion: " + expanded);
+    
+  }
+
+  
+  function checkOverflow(x) {
+    var el = document.getElementById(x);
+    if (el == null) {
+      console.log("it was null, but the id was " + x);
+      return;
+    }
+
+    // var curOverflow = el.style.overflow;
+
+    // if ( !curOverflow || curOverflow === "visible" )
+    //    el.style.overflow = "hidden";
+
+    var isOverflowing = el.clientWidth < el.scrollWidth 
+      || el.clientHeight < el.scrollHeight;
+
+    // el.style.overflow = curOverflow;
+
+    // setOverflow(isOverflowing);
+    return isOverflowing;
+    // return true;
+    // return false;
+  }
+  
+
 
   return (
     <List.Item>
@@ -24,23 +81,39 @@ const AnswerItem = (props) => {
           />
         </div>
         <List.Description>
-          {props.answer.length > PREVIEW_CHARS ? (
-            <>
-              <span className="qAnswer">
+          <div id={props.drewval} className={"qAnswer " + (expanded ? '' : 'test')}>        
+            {props.answer}
+          </div>
+          {() => checkOverflow(props.drewval)
+            ? <a onClick={() => setExpanded(!expanded)}>
+            Show {expanded ? 'less' : 'more'}
+             </a>
+            : <p>sup</p>
+          }
+          <button onClick={() => output(props.drewval)}>hey</button>
+          {(props.drewval)}
+          
+          
+
+
+          {/* {props.answer.length > PREVIEW_CHARS ? (
+            <div>    
+              <div className={"qAnswer " + (expanded ? '' : 'test')}>
+                {props.answer}
                 {expanded
                   ? props.answer
                   : `${props.answer.substring(0, PREVIEW_CHARS)}...`}
-              </span>
+              </div>
               <br />
               <a onClick={() => setExpanded(!expanded)}>
                 Show {expanded ? 'less' : 'more'}
               </a>
-            </>
+            </div>
           ) : (
             <>
-              <span className="qAnswer">{props.answer}</span>
+              <span className="test">{props.answer}</span>
             </>
-          )}
+          )} */}
         </List.Description>
       </List.Content>
     </List.Item>

--- a/client/src/components/AnswerItem.js
+++ b/client/src/components/AnswerItem.js
@@ -1,122 +1,65 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from 'react';
+import React, { useState, Component } from 'react';
 import { List } from 'semantic-ui-react';
 
 import '../styles/AnswerItem.css'
 
 import avatar from '../assets/images/askco-avatar.svg';
 
-const PREVIEW_CHARS = 200;
 
-
-
-
-const AnswerItem = (props) => {
-  const [expanded, setExpanded] = useState(false);
-  const [overflow, setOverflow] = useState(checkOverflow(props.drewval));
-  // const [overflow, setOverflow] = useState(true);
-
-  
-  var myBool = checkOverflow(props.drewval);
-
-  function componentDidMount() {
-    setOverflow(checkOverflow(props.drewval));
-    console.log("I RUN");
+export default class AnswerItem extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {expanded : false, overflow : false};
   }
 
-  function output(x) {
-    console.log("hello!!!!!!!!");
-    
-    console.log(x);
-    var el = document.getElementById(x);
-
-    var isOverflowing = el.clientWidth < el.scrollWidth 
-    || el.clientHeight < el.scrollHeight;
-
-    console.log("Overflowing? " + checkOverflow(x));
-
-    console.log("State of overflow: " + overflow);
-    console.log("State of exapnsion: " + expanded);
-    
+  componentDidMount() {
+    this.setOverflow();
+    window.addEventListener('resize', this.setOverflow);
   }
 
-  
-  function checkOverflow(x) {
-    var el = document.getElementById(x);
+  setOverflow = () => {
+    var el = document.getElementById(this.props.questionid);
     if (el == null) {
-      console.log("it was null, but the id was " + x);
+      console.log("Could not find element!");
       return;
     }
 
-    // var curOverflow = el.style.overflow;
+    var isOverflowing = el.clientWidth < el.scrollWidth || el.clientHeight < el.scrollHeight;
 
-    // if ( !curOverflow || curOverflow === "visible" )
-    //    el.style.overflow = "hidden";
-
-    var isOverflowing = el.clientWidth < el.scrollWidth 
-      || el.clientHeight < el.scrollHeight;
-
-    // el.style.overflow = curOverflow;
-
-    // setOverflow(isOverflowing);
-    return isOverflowing;
-    // return true;
-    // return false;
+    this.setState({overflow : isOverflowing});
   }
-  
 
 
-  return (
-    <List.Item>
-      <List.Content>
-        <div className="answerTitle">
-          <div className="answeredByName">
-            <span>A.</span>
-            {props.answeredBy || 'AskCo19'}
-          </div>
-          <img
-            src={props.answerByAvatarUrl || avatar}
-            className="answeredByIcon"
-            alt="answer avatar"
-          />
-        </div>
-        <List.Description>
-          <div id={props.drewval} className={"qAnswer " + (expanded ? '' : 'test')}>        
-            {props.answer}
-          </div>
-          {() => checkOverflow(props.drewval)
-            ? <a onClick={() => setExpanded(!expanded)}>
-            Show {expanded ? 'less' : 'more'}
-             </a>
-            : <p>sup</p>
-          }
-          <button onClick={() => output(props.drewval)}>hey</button>
-          {(props.drewval)}
-          
-          
-
-
-          {/* {props.answer.length > PREVIEW_CHARS ? (
-            <div>    
-              <div className={"qAnswer " + (expanded ? '' : 'test')}>
-                {props.answer}
-                {expanded
-                  ? props.answer
-                  : `${props.answer.substring(0, PREVIEW_CHARS)}...`}
-              </div>
-              <br />
-              <a onClick={() => setExpanded(!expanded)}>
-                Show {expanded ? 'less' : 'more'}
-              </a>
+  render() {
+    return (
+      <List.Item>
+        <List.Content>
+          <div className="answerTitle">
+            <div className="answeredByName">
+              <span>A.</span>
+              {this.props.answeredBy || 'AskCo19'}
             </div>
-          ) : (
-            <>
-              <span className="test">{props.answer}</span>
-            </>
-          )} */}
-        </List.Description>
-      </List.Content>
-    </List.Item>
-  );
-};
-export default AnswerItem;
+            <img
+              src={this.props.answerByAvatarUrl || avatar}
+              className="answeredByIcon"
+              alt="answer avatar"
+            />
+          </div>
+          <List.Description>
+            <div id={this.props.questionid} className={"qAnswer " + (this.state.expanded ? '' : 'overflow')}>        
+              {this.props.answer}
+            </div>
+            {this.state.overflow
+              ? <a onClick={() => this.setState({expanded : !this.state.expanded})}>
+              Show {this.state.expanded ? 'less' : 'more'}
+               </a>
+              : null
+            }
+          </List.Description>
+        </List.Content>
+      </List.Item>
+    );
+  }
+}
+

--- a/client/src/components/QuestionBoard.js
+++ b/client/src/components/QuestionBoard.js
@@ -62,7 +62,7 @@ export default class QuestionBoard extends Component {
 
                 <List>
                   {question.answers.map((answer, index) => {
-                    return <AnswerItem answer={answer} key={index} />;
+                    return <AnswerItem answer={answer} key={index} drewval={question.id}/>;
                   })}
 
                   {question.images &&

--- a/client/src/components/QuestionBoard.js
+++ b/client/src/components/QuestionBoard.js
@@ -62,7 +62,7 @@ export default class QuestionBoard extends Component {
 
                 <List>
                   {question.answers.map((answer, index) => {
-                    return <AnswerItem answer={answer} key={index} drewval={question.id}/>;
+                    return <AnswerItem answer={answer} key={index} questionid={question.id}/>;
                   })}
 
                   {question.images &&

--- a/client/src/styles/AnswerItem.css
+++ b/client/src/styles/AnswerItem.css
@@ -1,0 +1,8 @@
+.test {
+    line-height: 1.5em;
+    height: 3em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: blue;
+    
+}

--- a/client/src/styles/AnswerItem.css
+++ b/client/src/styles/AnswerItem.css
@@ -1,8 +1,5 @@
-.test {
+.overflow {
     line-height: 1.5em;
     height: 3em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: blue;
-    
+    overflow: hidden;        
 }


### PR DESCRIPTION
## Motivation

Addressing issue GitHub issue #148 

## Implementation

Refactored the const AnswerItem as a class so that the physician answer could be analyzed after being received from the API so that the code could tell how many lines the returned answer would take up and determine if the "Show More" button would be necessary. A listener on the window resize event was also added so the page could respond dynamically if needed.

## Screenshots/Links

![git1](https://user-images.githubusercontent.com/54967078/79701541-f9a9fc80-826b-11ea-9065-c87f70a2ce85.png)

![git2](https://user-images.githubusercontent.com/54967078/79701547-02023780-826c-11ea-9521-18df5039fdf8.png)

┆Issue is synchronized with this [Trello card](https://trello.com/c/Liat9oxS) by [Unito](https://www.unito.io/learn-more)
