### PR TITLE
#159: Fix menu collapse on scrolling down

### DIFF
--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -1,13 +1,8 @@
-/* eslint-disable no-unused-vars */
 import React, { Component } from 'react';
 import { Button } from 'semantic-ui-react';
-import { bindActionCreators } from 'redux';
 import { withTranslation } from 'react-i18next';
 import { withRouter } from 'react-router-dom';
 import styles from '../styles/NavLink.css';
-import { changeLanguage } from '../actions';
-
-import LanguageSelector from './LanguageSelector';
 
 class NavMenu extends Component {
   constructor() {
@@ -19,17 +14,17 @@ class NavMenu extends Component {
     this.showmenu = this.showmenu.bind(this);
     this.WrapperRef = this.WrapperRef.bind(this);
     this.handleClick = this.handleClick.bind(this);
-    this.hideMenuMobileMenu = this.hideMenuMobileMenu.bind(this);
+    this.hideMobileMenu = this.hideMobileMenu.bind(this);
   }
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClick);
-    document.addEventListener('scroll', this.hideMenuMobileMenu);
+    document.addEventListener('scroll', this.hideMobileMenu);
   }
 
   componentWillUnmount() {
     document.removeEventListener('mousedown ', this.handleClick);
-    document.addEventListener('scroll', this.hideMenuMobileMenu);
+    document.addEventListener('scroll', this.hideMobileMenu);
   }
 
   WrapperRef(node) {
@@ -42,7 +37,7 @@ class NavMenu extends Component {
     });
   }
 
-  hideMenuMobileMenu() {
+  hideMobileMenu() {
     if (window.innerWidth < 480) {
       this.setState({
         showMenu: false,
@@ -56,12 +51,8 @@ class NavMenu extends Component {
     }
   }
 
-  handleChangeLanguage = (language) => {
-    return () => this.prop.changeLanguage(language);
-  };
-
   render() {
-    const { t, handleChangeLanguage } = this.props;
+    const { t } = this.props;
     return (
       <div>
         <Button id="menu" className="ui icon button" onClick={this.showmenu}>
@@ -130,35 +121,6 @@ class NavMenu extends Component {
                       {t('navLink:logIn')}
                     </a>
                   </li>
-                  {/*                   <li>
-                    <span rel="noopener noreferrer">
-                      {t('navLink:language')}
-                    </span>
-                    <div>
-                      <LanguageSelector className="sidebar-language-dropdown" handleChangeLanguage={this.handleChangeLanguage}/>
-                    </div>
-                  </li> */}
-
-                  {/*                   <div>
-                    {this.props.account ? (
-                      <Button
-                        onClick={this.props.onSignOut}
-                        className="logInlogOut"
-                      >
-                        {t('navLink:logOut')}
-                      </Button>
-                    ) : (
-                      <Button
-                        target="_blank"
-                        onClick={() =>
-                          this.props.history.push('/bIiOOIIqgwEXwUU3SaD0F9')
-                        }
-                        className="logInlogOut"
-                      >
-                        {t('navLink:logIn')}
-                      </Button>
-                    )}
-                  </div> */}
                 </ul>
               </nav>
             </div>
@@ -169,11 +131,4 @@ class NavMenu extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) =>
-  bindActionCreators(
-    {
-      changeLanguage,
-    },
-    dispatch
-  );
 export default withTranslation()(withRouter(NavMenu));

--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -1,10 +1,11 @@
+/* eslint-disable no-unused-vars */
 import React, { Component } from 'react';
 import { Button } from 'semantic-ui-react';
 import { bindActionCreators } from 'redux';
 import { withTranslation } from 'react-i18next';
 import { withRouter } from 'react-router-dom';
 import styles from '../styles/NavLink.css';
-import {changeLanguage} from '../actions';
+import { changeLanguage } from '../actions';
 
 import LanguageSelector from './LanguageSelector';
 
@@ -18,14 +19,17 @@ class NavMenu extends Component {
     this.showmenu = this.showmenu.bind(this);
     this.WrapperRef = this.WrapperRef.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.hideMenuMobileMenu = this.hideMenuMobileMenu.bind(this);
   }
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClick);
+    document.addEventListener('scroll', this.hideMenuMobileMenu);
   }
 
   componentWillUnmount() {
     document.removeEventListener('mousedown ', this.handleClick);
+    document.addEventListener('scroll', this.hideMenuMobileMenu);
   }
 
   WrapperRef(node) {
@@ -38,6 +42,14 @@ class NavMenu extends Component {
     });
   }
 
+  hideMenuMobileMenu() {
+    if (window.innerWidth < 480) {
+      this.setState({
+        showMenu: false,
+      });
+    }
+  }
+
   handleClick(event) {
     if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
       this.showmenu();
@@ -45,11 +57,8 @@ class NavMenu extends Component {
   }
 
   handleChangeLanguage = (language) => {
-    return() => this.prop.changeLanguage(language);
+    return () => this.prop.changeLanguage(language);
   };
-
-
-
 
   render() {
     const { t, handleChangeLanguage } = this.props;
@@ -121,7 +130,7 @@ class NavMenu extends Component {
                       {t('navLink:logIn')}
                     </a>
                   </li>
-{/*                   <li>
+                  {/*                   <li>
                     <span rel="noopener noreferrer">
                       {t('navLink:language')}
                     </span>
@@ -130,7 +139,7 @@ class NavMenu extends Component {
                     </div>
                   </li> */}
 
-{/*                   <div>
+                  {/*                   <div>
                     {this.props.account ? (
                       <Button
                         onClick={this.props.onSignOut}

--- a/client/src/components/NavLink.js
+++ b/client/src/components/NavLink.js
@@ -14,17 +14,14 @@ class NavMenu extends Component {
     this.showmenu = this.showmenu.bind(this);
     this.WrapperRef = this.WrapperRef.bind(this);
     this.handleClick = this.handleClick.bind(this);
-    this.hideMobileMenu = this.hideMobileMenu.bind(this);
   }
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClick);
-    document.addEventListener('scroll', this.hideMobileMenu);
   }
 
   componentWillUnmount() {
     document.removeEventListener('mousedown ', this.handleClick);
-    document.addEventListener('scroll', this.hideMobileMenu);
   }
 
   WrapperRef(node) {
@@ -35,14 +32,6 @@ class NavMenu extends Component {
     this.setState({
       showMenu: !this.state.showMenu,
     });
-  }
-
-  hideMobileMenu() {
-    if (window.innerWidth < 480) {
-      this.setState({
-        showMenu: false,
-      });
-    }
   }
 
   handleClick(event) {

--- a/client/src/styles/NavLink.css
+++ b/client/src/styles/NavLink.css
@@ -15,7 +15,6 @@
 }
 
 .ui.right.sidebar {
-  position: absolute;
   background: #006eaa;
 }
 


### PR DESCRIPTION
## Motivation
Resolves #159 

## Implementation
Menu remains fixed on large screens when scrolling but is collapsed on smaller screens. 

Also the Navlink component has a couple of unused vars causing linting errors. Momentarily blocking this to enable the commits as shown on  [line 1](https://github.com/cnagadya/covid19/blob/%23159-Fix-Menu-Collapse/client/src/components/NavLink.js#L1). Should all these vars be removed 
i.e [changeLanguage](https://github.com/cnagadya/covid19/blob/%23159-Fix-Menu-Collapse/client/src/components/NavLink.js#L8), [handleChangelanguage](https://github.com/cnagadya/covid19/blob/%23159-Fix-Menu-Collapse/client/src/components/NavLink.js#L59-#L64), [LanguageSelector](https://github.com/cnagadya/covid19/blob/%23159-Fix-Menu-Collapse/client/src/components/NavLink.js#L10) and [mapDispatchToProps](https://github.com/cnagadya/covid19/blob/%23159-Fix-Menu-Collapse/client/src/components/NavLink.js#L172-#L178). The were used in the [currently commented out code block](https://github.com/cnagadya/covid19/blob/%23159-Fix-Menu-Collapse/client/src/components/NavLink.js#L133-#L161)
![image](https://user-images.githubusercontent.com/26176338/80986824-63600400-8e31-11ea-901c-b844cef396bc.png)

## Screenshots/Links

![askco19](https://user-images.githubusercontent.com/26176338/80986592-11b77980-8e31-11ea-90da-62914c522d03.gif)