### PR TITLE
Add link to registration form to the unverified user welcome message

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     'prettier',
     'prettier/react',
   ],
-  plugins: ['jsx-a11y', 'prettier'],
+  plugins: ['jsx-a11y', 'prettier', 'react-hooks'],
   rules: {
     semi: 0,
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
@@ -26,6 +26,8 @@ module.exports = {
     'jsx-a11y/click-events-have-key-events': 'off',
     'react/no-unescaped-entities': 'off',
     'react/no-array-index-key': 'off',
-    'jsx-a11y/no-static-element-interactions': 'off'
+    'jsx-a11y/no-static-element-interactions': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 };

--- a/client/public/locales/de/physicianView.json
+++ b/client/public/locales/de/physicianView.json
@@ -1,6 +1,6 @@
 {
-  "welcome": "[DE] Welcome, ",
-  "unverifiedUserMessage": "[DE] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[DE] Welcome, {{userFullName}}",
+  "unverifiedUserMessage": "[DE] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit <0>a Physician Registration form</0> if you have not already done so. Thank you.",
   "buttons": {
     "answeredQuestions": "[DE] Answered Questions",
     "unansweredQuestions": "[DE] Unanswered Questions",

--- a/client/public/locales/de/physicianView.json
+++ b/client/public/locales/de/physicianView.json
@@ -1,11 +1,11 @@
 {
-  "welcome": "Welcome, ",
-  "unverifiedUserMessage": "You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[DE] Welcome, ",
+  "unverifiedUserMessage": "[DE] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
   "buttons": {
-    "answeredQuestions": "Answered Questions",
-    "unansweredQuestions": "Unanswered Questions",
-    "televideo": "Televideo",
-    "logOut": "Log out"
+    "answeredQuestions": "[DE] Answered Questions",
+    "unansweredQuestions": "[DE] Unanswered Questions",
+    "televideo": "[DE] Televideo",
+    "logOut": "[DE] Log out"
   },
-  "errorMessage": "Sorry, something went wrong!"
+  "errorMessage": "[DE] Sorry, something went wrong!"
 }

--- a/client/public/locales/en/physicianView.json
+++ b/client/public/locales/en/physicianView.json
@@ -1,6 +1,6 @@
 {
-  "welcome": "Welcome, ",
-  "unverifiedUserMessage": "You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "Welcome, {{userFullName}}",
+  "unverifiedUserMessage": "You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit <0>a Physician Registration form</0> if you have not already done so. Thank you.",
   "buttons": {
     "answeredQuestions": "Answered Questions",
     "unansweredQuestions": "Unanswered Questions",

--- a/client/public/locales/hi-IN/physicianView.json
+++ b/client/public/locales/hi-IN/physicianView.json
@@ -1,11 +1,11 @@
 {
-  "welcome": "Welcome, ",
-  "unverifiedUserMessage": "You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[hi-IN] Welcome, ",
+  "unverifiedUserMessage": "[hi-IN] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
   "buttons": {
-    "answeredQuestions": "Answered Questions",
-    "unansweredQuestions": "Unanswered Questions",
-    "televideo": "Televideo",
-    "logOut": "Log out"
+    "answeredQuestions": "[hi-IN] Answered Questions",
+    "unansweredQuestions": "[hi-IN] Unanswered Questions",
+    "televideo": "[hi-IN] Televideo",
+    "logOut": "[hi-IN] Log out"
   },
-  "errorMessage": "Sorry, something went wrong!"
+  "errorMessage": "[hi-IN] Sorry, something went wrong!"
 }

--- a/client/public/locales/hi-IN/physicianView.json
+++ b/client/public/locales/hi-IN/physicianView.json
@@ -1,6 +1,6 @@
 {
-  "welcome": "[hi-IN] Welcome, ",
-  "unverifiedUserMessage": "[hi-IN] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[hi-IN] Welcome, {{userFullName}}",
+  "unverifiedUserMessage": "[hi-IN] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit <0>a Physician Registration form</0> if you have not already done so. Thank you.",
   "buttons": {
     "answeredQuestions": "[hi-IN] Answered Questions",
     "unansweredQuestions": "[hi-IN] Unanswered Questions",

--- a/client/public/locales/ko-KR/physicianView.json
+++ b/client/public/locales/ko-KR/physicianView.json
@@ -1,11 +1,11 @@
 {
-  "welcome": "Welcome, ",
-  "unverifiedUserMessage": "You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[ko-KR] Welcome, ",
+  "unverifiedUserMessage": "[ko-KR] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
   "buttons": {
-    "answeredQuestions": "Answered Questions",
-    "unansweredQuestions": "Unanswered Questions",
-    "televideo": "Televideo",
-    "logOut": "Log out"
+    "answeredQuestions": "[ko-KR] Answered Questions",
+    "unansweredQuestions": "[ko-KR] Unanswered Questions",
+    "televideo": "[ko-KR] Televideo",
+    "logOut": "[ko-KR] Log out"
   },
-  "errorMessage": "Sorry, something went wrong!"
+  "errorMessage": "[ko-KR] Sorry, something went wrong!"
 }

--- a/client/public/locales/ko-KR/physicianView.json
+++ b/client/public/locales/ko-KR/physicianView.json
@@ -1,6 +1,6 @@
 {
-  "welcome": "[ko-KR] Welcome, ",
-  "unverifiedUserMessage": "[ko-KR] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[ko-KR] Welcome, {{userFullName}}",
+  "unverifiedUserMessage": "[ko-KR] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit <0>a Physician Registration form</0> if you have not already done so. Thank you.",
   "buttons": {
     "answeredQuestions": "[ko-KR] Answered Questions",
     "unansweredQuestions": "[ko-KR] Unanswered Questions",

--- a/client/public/locales/zh-cn/physicianView.json
+++ b/client/public/locales/zh-cn/physicianView.json
@@ -1,11 +1,11 @@
 {
-  "welcome": "Welcome, ",
-  "unverifiedUserMessage": "You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
+  "welcome": "[zh-cn] Welcome, ",
+  "unverifiedUserMessage": "[zh-cn] You have been granted READ-ONLY access to rate, review, and flag answers until your account has been verified. Please submit a Physician Registration form if you have not already done so. Thank you.",
   "buttons": {
-    "answeredQuestions": "Answered Questions",
-    "unansweredQuestions": "Unanswered Questions",
-    "televideo": "Televideo",
-    "logOut": "Log out"
+    "answeredQuestions": "[zh-cn] Answered Questions",
+    "unansweredQuestions": "[zh-cn] Unanswered Questions",
+    "televideo": "[zh-cn] Televideo",
+    "logOut": "[zh-cn] Log out"
   },
-  "errorMessage": "Sorry, something went wrong!"
+  "errorMessage": "[zh-cn] Sorry, something went wrong!"
 }

--- a/client/src/components/AnswerItem.js
+++ b/client/src/components/AnswerItem.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Trans, withTranslation } from 'react-i18next';
 import { ReactTinyLink } from 'react-tiny-link';
-import { List, Image, Label, Button, Icon } from 'semantic-ui-react';
+import { List, Image, Label } from 'semantic-ui-react';
 
 import clockIcon from '../assets/images/clockIcon.png';
 
@@ -44,10 +44,7 @@ const AnswerItem = (props) => {
               <img src={clockIcon} alt="clock_icon" height="11" width="11" />
             </span3>
             <span4>Posted: {firstAnsweredOn}</span4>
-            <span5>
-              Last Edited:{' '}
-              {lastAnsweredOn}
-            </span5>
+            <span5>Last Edited: {lastAnsweredOn}</span5>
           </div>
           <img
             src={props.answerByAvatarUrl || avatar}

--- a/client/src/components/PhysicianView.js
+++ b/client/src/components/PhysicianView.js
@@ -68,7 +68,7 @@ const PhysicianView = (props) => {
             </Message>
           ) : (
             isMessageVisible && (
-              <Message color="green" onDismiss={() => handleDismissMessage()}>
+              <Message color="green" onDismiss={handleDismissMessage}>
                 {props.t('physicianView:welcome')} {props.authuser.fullname}
               </Message>
             )

--- a/client/src/components/PhysicianView.js
+++ b/client/src/components/PhysicianView.js
@@ -1,7 +1,10 @@
-import React, { Component } from 'react';
+/* eslint-disable jsx-a11y/anchor-has-content */
+/* eslint-disable no-shadow */
+
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { withTranslation } from 'react-i18next';
+import { Trans, withTranslation } from 'react-i18next';
 import { Menu, Button, Message, Grid } from 'semantic-ui-react';
 
 import '../styles/QuestionBoard.css';
@@ -17,155 +20,154 @@ import AnswerForm from './AnswerForm';
 import NavMenu from './NavLink';
 import Footer from './Footer';
 
-class PhysicianView extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isMessageVisible: true,
-      showUnanswered: true,
-    };
-    this.idToken = null;
-  }
+const PhysicianView = (props) => {
+  const [isMessageVisible, setIsMessageVisible] = useState(true);
+  const [isUnansweredShown, setIsUnansweredShown] = useState(true);
 
-  componentDidMount() {
-    this.props.fetchUnansweredQuestions();
-    this.props.fetchQuestions();
-  }
+  const { fetchUnansweredQuestions, fetchQuestions } = props;
 
-  handleToggleView(showUnanswered) {
-    this.setState({ showUnanswered });
-  }
+  useEffect(() => {
+    fetchUnansweredQuestions();
+    fetchQuestions();
+  }, [fetchUnansweredQuestions, fetchQuestions]);
 
-  handleDismissMessage = () => {
-    this.setState({ isMessageVisible: false });
+  const handleToggleView = (showUnanswered) => {
+    setIsUnansweredShown(showUnanswered);
   };
 
-  render() {
-    return !this.props.authuser ? (
-      <PhysicianLogin onSignIn={this.props.onSignIn} />
-    ) : (
-      <>
-        <NavMenu
-          account={this.props.account}
-          onSignOut={this.props.onSignOut}
-          idToken={this.props.idToken}
-        />
+  const handleDismissMessage = () => {
+    setIsMessageVisible(false);
+  };
 
-        <Grid centered columns={2} stackable>
-          <Grid.Column>
-            {this.props.authuser.profilestatus === 'level 0' ? (
-              <Message
-                color="yellow"
-                header={`${this.props.t('physicianView:welcome')} ${
-                  this.props.authuser.fullname
-                }`}
-                content={this.props.t('physicianView:unverifiedUserMessage')}
-              />
-            ) : (
-              this.state.isMessageVisible && (
-                <Message color="green" onDismiss={this.handleDismissMessage}>
-                  {this.props.t('physicianView:welcome')}{' '}
-                  {this.props.authuser.fullname}
-                </Message>
-              )
-            )}
-          </Grid.Column>
-        </Grid>
+  return !props.authuser ? (
+    <PhysicianLogin onSignIn={props.onSignIn} />
+  ) : (
+    <>
+      <NavMenu
+        account={props.account}
+        onSignOut={props.onSignOut}
+        idToken={props.idToken}
+      />
 
-        <div className="physician-view-container">
-          <Menu secondary style={{ display: 'flex', flexDirection: 'column' }}>
-            <div className="right menu" style={{ margin: '1rem 0' }}>
-              <a
-                href="https://ai-passion.appspot.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="active item"
-              >
-                {this.props.t('physicianView:buttons.televideo')}
-              </a>
-            </div>
-            <Menu.Menu position="right">
-              {this.props.account && (
-                <Menu.Item
-                  active
-                  name={this.props.t('physicianView:buttons.logOut')}
-                  onClick={this.props.onSignOut}
+      <Grid centered columns={2} stackable>
+        <Grid.Column>
+          {props.authuser.profilestatus === 'level 0' ? (
+            <Message color="yellow">
+              <Message.Header>
+                {props.t('physicianView:welcome', {
+                  returnObjects: true,
+                  userFullName: props.authuser.fullname,
+                })}
+              </Message.Header>
+              <Trans i18nKey="physicianView:unverifiedUserMessage">
+                <a
+                  href="//www.askco19.com/j-2-lightbox.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
                 />
-              )}
-            </Menu.Menu>
-          </Menu>
-          <div className="buttonGroupCustom">
-            {this.props.account && (
-              <Button.Group>
-                <Button
-                  basic
-                  color="blue"
-                  onClick={() => this.handleToggleView(true)}
-                  active={this.state.showUnanswered}
-                >
-                  {this.props.t('physicianView:buttons.unansweredQuestions')}
-                </Button>
-                <Button
-                  basic
-                  color="green"
-                  onClick={() => this.handleToggleView(false)}
-                  active={!this.state.showUnanswered}
-                >
-                  {this.props.t('physicianView:buttons.answeredQuestions')}
-                </Button>
-              </Button.Group>
-            )}
-          </div>
-          <section className="container">
-            {this.props.error && (
-              <Message negative>
-                <Message.Header>
-                  {this.props.t('physicianView:errorMessage')}
-                </Message.Header>
-                <p>{this.props.error}</p>
+              </Trans>
+            </Message>
+          ) : (
+            isMessageVisible && (
+              <Message color="green" onDismiss={() => handleDismissMessage()}>
+                {props.t('physicianView:welcome')} {props.authuser.fullname}
               </Message>
-            )}
-          </section>
-          <section className="data" />
-          <div>
-            <Grid centered columns={2} stackable>
-              <Grid.Column>
-                {this.state.showUnanswered &&
-                  this.props.account &&
-                  this.props.unansweredQuestions &&
-                  this.props.unansweredQuestions.map((q, idx) => (
-                    <AnswerForm
-                      history={this.props.history}
-                      userToken={this.props.idToken}
-                      profileStatus={this.props.authuser.profilestatus}
-                      q={q}
-                      idx={idx}
-                      showUnanswered={this.state.showUnanswered}
-                    />
-                  ))}
+            )
+          )}
+        </Grid.Column>
+      </Grid>
 
-                {!this.state.showUnanswered &&
-                  this.props.account &&
-                  this.props.questions &&
-                  this.props.questions.map((q, idx) => (
-                    <AnswerForm
-                      history={this.props.history}
-                      userToken={this.props.idToken}
-                      profileStatus={this.props.authuser.profilestatus}
-                      q={q}
-                      idx={idx}
-                      showUnanswered={this.state.showUnanswered}
-                    />
-                  ))}
-              </Grid.Column>
-            </Grid>
+      <div className="physician-view-container">
+        <Menu secondary style={{ display: 'flex', flexDirection: 'column' }}>
+          <div className="right menu" style={{ margin: '1rem 0' }}>
+            <a
+              href="https://ai-passion.appspot.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="active item"
+            >
+              {props.t('physicianView:buttons.televideo')}
+            </a>
           </div>
-          <Footer />
+          <Menu.Menu position="right">
+            {props.account && (
+              <Menu.Item
+                active
+                name={props.t('physicianView:buttons.logOut')}
+                onClick={props.onSignOut}
+              />
+            )}
+          </Menu.Menu>
+        </Menu>
+        <div className="buttonGroupCustom">
+          {props.account && (
+            <Button.Group>
+              <Button
+                basic
+                color="blue"
+                onClick={() => handleToggleView(true)}
+                active={isUnansweredShown}
+              >
+                {props.t('physicianView:buttons.unansweredQuestions')}
+              </Button>
+              <Button
+                basic
+                color="green"
+                onClick={() => handleToggleView(false)}
+                active={!isUnansweredShown}
+              >
+                {props.t('physicianView:buttons.answeredQuestions')}
+              </Button>
+            </Button.Group>
+          )}
         </div>
-      </>
-    );
-  }
-}
+        <section className="container">
+          {props.error && (
+            <Message negative>
+              <Message.Header></Message.Header>
+              <p>{props.error}</p>
+            </Message>
+          )}
+        </section>
+        <section className="data" />
+        <div>
+          <Grid centered columns={2} stackable>
+            <Grid.Column>
+              {isUnansweredShown &&
+                props.account &&
+                props.unansweredQuestions &&
+                props.unansweredQuestions.map((q, idx) => (
+                  <AnswerForm
+                    history={props.history}
+                    userToken={props.idToken}
+                    profileStatus={props.authuser.profilestatus}
+                    q={q}
+                    idx={idx}
+                    showUnanswered={isUnansweredShown}
+                  />
+                ))}
+
+              {!isUnansweredShown &&
+                props.account &&
+                props.questions &&
+                props.questions.map((q, idx) => (
+                  <AnswerForm
+                    history={props.history}
+                    userToken={props.idToken}
+                    profileStatus={props.authuser.profilestatus}
+                    q={q}
+                    idx={idx}
+                    showUnanswered={isUnansweredShown}
+                  />
+                ))}
+            </Grid.Column>
+          </Grid>
+        </div>
+        <Footer />
+      </div>
+    </>
+  );
+};
 
 const mapStateToProps = (state) => {
   return {

--- a/client/src/components/PhysicianView.js
+++ b/client/src/components/PhysicianView.js
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-has-content */
-/* eslint-disable no-shadow */
-
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -24,6 +21,7 @@ const PhysicianView = (props) => {
   const [isMessageVisible, setIsMessageVisible] = useState(true);
   const [isUnansweredShown, setIsUnansweredShown] = useState(true);
 
+  /* eslint-disable-next-line no-shadow */
   const { fetchUnansweredQuestions, fetchQuestions } = props;
 
   useEffect(() => {
@@ -60,6 +58,7 @@ const PhysicianView = (props) => {
                 })}
               </Message.Header>
               <Trans i18nKey="physicianView:unverifiedUserMessage">
+                {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
                 <a
                   href="//www.askco19.com/j-2-lightbox.html"
                   target="_blank"


### PR DESCRIPTION
## Motivation

An unverified user saw a message encouraging them to register, but without an explanation how to do that right now. That user experience needed to be fixed.

## Description

This PR adds a link to the Unbounce form, which is still the way to register, to the welcome message for unverified physicians.

Fixes #316 

## Implementation

- a link was added to the Message component using the Trans component from i18next
- the PhysicianView was refactored to a function-based React component - this made it possible to pass the eslint pre-commit check by disabling the `anchor-has-content` rule, but is a good more modern practice anyway
- another rule, `no-shadow` had to be bypassed because the destructured functions, which needed to be passed to `useEffect` in props were shadowing the imported actions, and having them left undestructured resulted in a loop, because then the functions were called whenever any of the props changed

Also:
- language names were prepended to translations of PhysicianView that are yet to be added
- two no-unused-vars warnings were removed

## Type of change

New feature

## Screenshots/Links

<img width="914" alt="Screenshot 2020-06-18 at 00 52 10" src="https://user-images.githubusercontent.com/457999/84958596-02993c00-b0fe-11ea-89dd-e58abb7f8133.png">

<img width="1440" alt="Screenshot 2020-06-18 at 00 52 29" src="https://user-images.githubusercontent.com/457999/84958605-075df000-b0fe-11ea-9ee3-7092e92f21cb.png">
