### PR TITLE
Responsify header

### DIFF
--- a/client/src/components/FileUpload.js
+++ b/client/src/components/FileUpload.js
@@ -104,6 +104,7 @@ class Upload extends Component {
     if (this.state.successfullUploaded) {
       return (
         <button
+          className="file-upload-button"
           onClick={() =>
             this.setState({ files: [], successfullUploaded: false })
           }
@@ -114,6 +115,7 @@ class Upload extends Component {
     }
     return (
       <button
+        className="file-upload-button"
         disabled={this.state.files.length < 0 || this.state.uploading}
         onClick={this.uploadFiles}
       >

--- a/client/src/components/NavMenu.js
+++ b/client/src/components/NavMenu.js
@@ -55,8 +55,10 @@ class NavMenu extends Component {
             <div
               className={`ui visible right demo vertical sidebar labeled icon menu ${styles.NavMenu}`}
             >
-              <div onClick={this.toggleMenu} className="close-menu">
-                x
+              <div className="close-menu-wrapper">
+                <button onClick={this.toggleMenu} className="close-menu-button">
+                  x
+                </button>
               </div>
               <nav>
                 <ul>

--- a/client/src/styles/FileUpload.css
+++ b/client/src/styles/FileUpload.css
@@ -66,7 +66,7 @@
   align-items: center;
 }
 
-button {
+.file-upload-button {
   font-family: 'Roboto medium', sans-serif;
   font-size: 14px;
   display: inline-block;
@@ -91,7 +91,7 @@ button {
   outline: 0;
 }
 
-button:disabled {
+.file-upload-button:disabled {
   background: rgb(189, 189, 189);
   cursor: default;
 }

--- a/client/src/styles/NavMenu.css
+++ b/client/src/styles/NavMenu.css
@@ -18,6 +18,12 @@
   background: #006eaa;
 }
 
+@media (max-width: 600px) {
+  .ui.vertical.icon.menu {
+    width: 100vw;
+  }
+}
+
 nav {
   height: 100vh;
   display: grid;
@@ -61,14 +67,29 @@ nav ul li a:hover {
   opacity: 0.75;
 }
 
-.close-menu {
-  text-align: right;
-  font-size: 2em;
-  padding: 10px 10px 0px 0px;
+.close-menu-wrapper {
+  margin-bottom: 2em;
+  position: relative;
+}
+
+.close-menu-button {
+  background: none;
+  border: 0;
   color: white;
   cursor: pointer;
-  opacity: 1;
+  font-size: 2em;
+  line-height: 1.75em;
+  outline: 0;
+  padding: 15px;
+  position: absolute;
+  right: 0;
+  text-align: right;
 }
+
+.close-menu-button:hover {
+  color: white;
+}
+
 .row#sponsors {
   margin-top: 500px;
   margin-bottom: 60px;

--- a/client/src/styles/NavMenu.css
+++ b/client/src/styles/NavMenu.css
@@ -84,6 +84,7 @@ button#menu.ui.button {
 
 button#menu.ui.button i.bars.icon {
   font-size: 2em;
+  line-height: 1.75em;
   margin: 0;
   height: 100%;
   color: #006eaa;

--- a/client/src/styles/NavMenu.css
+++ b/client/src/styles/NavMenu.css
@@ -66,6 +66,7 @@ nav ul li a:hover {
   font-size: 2em;
   padding: 10px 10px 0px 0px;
   color: white;
+  cursor: pointer;
   opacity: 1;
 }
 .row#sponsors {

--- a/client/src/styles/QuestionBoard.css
+++ b/client/src/styles/QuestionBoard.css
@@ -27,20 +27,6 @@ body {
   font-style: italic;
 }
 
-.searchBar {
-  display: flex;
-  justify-content: center;
-}
-
-.searchBar .input {
-  width: 100%;
-  max-width: 700px;
-}
-
-.ui.search .prompt {
-  border-radius: 30px;
-}
-
 .qCard {
   padding: 40px !important;
   border: none;

--- a/client/src/styles/SearchBar.css
+++ b/client/src/styles/SearchBar.css
@@ -1,3 +1,23 @@
 .searchBarDiv {
   margin-right: 10%;
 }
+
+.searchBar {
+  display: flex;
+  justify-content: center;
+}
+
+.searchBar .input {
+  max-width: 700px;
+  width: 100%;
+}
+
+.ui.search > .results {
+  left: auto;
+  max-width: 700px;
+  width: 100%;
+}
+
+.ui.search .prompt {
+  border-radius: 30px;
+}


### PR DESCRIPTION
## Motivation

On smallest screens the nav menu covered almost the whole screen but not all of it, which didn't look good.
While working on this noticed that the search results don't look good either, as they were shown in a small misaligned popup.

## Description

Made the menu full-width on smallest screens.
Fixed search results to match the input width.
Fixed hamburger icon alignment.
Improved close button styles, aligning it with the now covered hamburger icon, so that the user doesn't have to shift their finger when expanding and collapsing.

Fixes #305 

## Implementation

* Needed to add some overrides on top of semantic UI elements.
* Over-general styles for `button` were moved to a specific class for file upload, so that button elements can be used more freely.

## Type of change

New feature

## Screenshots/Links

Nav menu - desktop:

<img width="591" alt="Screenshot 2020-06-19 at 22 01 01" src="https://user-images.githubusercontent.com/457999/85175747-6c3d5580-b278-11ea-9352-79f966f3686d.png">

Nav menu - phone:

<img width="283" alt="Screenshot 2020-06-19 at 21 56 05" src="https://user-images.githubusercontent.com/457999/85175453-bbcf5180-b277-11ea-9722-719deb09e5c7.png">

Search bar and hamburger icon - before:

<img width="1437" alt="Screenshot 2020-06-19 at 21 57 53" src="https://user-images.githubusercontent.com/457999/85175653-36986c80-b278-11ea-81e1-c2eee56e009c.png">

Search Bar and hamburger icon - after:

<img width="1440" alt="Screenshot 2020-06-19 at 21 57 38" src="https://user-images.githubusercontent.com/457999/85175662-3d26e400-b278-11ea-8ceb-cd108301b305.png">


